### PR TITLE
Add option to match including current container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [??] - ??
+### Added
+- Add option to match including current container name
+
 ## [3.9.0] - 10 Feb 2021
 ### Added
 - Remove temporary tabs if keepOldTabs is true. Fixes #93

--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ Install the latest release for Firefox from [AMO](https://addons.mozilla.org/en-
 
 `@.+\.amazon\.co\.uk$, Shopping` will be treat as `.+\.amazon\.co\.uk$` regex. (suitable to subdomains and complex paths)
 
+## Matching with existing container name
+With the option "Match current container name" turned on:
 
+`<>amazon.co.uk, Shopping` will open all amazon.co.uk (not subdomains) links in Shopping container, but only if not already in a container
+
+`@<shopping>(?!.+\.amazon\.co\.uk).*, No Container` will open all links from inside the Shopping continer that are _not_ to .amazon.co.uk subdomains in the default No Container
+
+`@<(?!profile \d).*>.+\.facebook.com$, Profile 1` will open all links to facebook.com in Profile 1 container, unless they are already in Profile 1, Profile 2, Profile 3 etc.
 
 # Development
 

--- a/src/Storage/HostStorage.js
+++ b/src/Storage/HostStorage.js
@@ -8,13 +8,13 @@ class HostStorage extends PrefixStorage {
     this.SET_KEY = 'host';
   }
 
-  get(url, matchDomainOnly) {
+  get(url, matchDomainOnly, currentContainerName) {
     return super.getAll().then(maps => {
       const sorted = sortMaps(Object.keys(maps).map(key => maps[key]));
       // Sorts by domain length, then by path length
       return sorted.find((map) => {
         try{
-          return matchesSavedMap( url, matchDomainOnly, map);
+          return matchesSavedMap( url, matchDomainOnly, currentContainerName, map);
         } catch (e) {
           console.error('Error matching maps', map, url, matchDomainOnly, e);
           return false;

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -74,10 +74,34 @@ describe('utils', () => {
         describe('without host prefix', () => {
           it('should match url without path', () => {
             expect(
-                utils.matchesSavedMap('https://duckduckgo.com', matchDomainOnly, {
+                utils.matchesSavedMap('https://duckduckgo.com', matchDomainOnly, undefined, {
                   host: 'duckduckgo.com',
                 })
             ).toBe(true);
+          });
+          it('should match url with container', () => {
+            expect(utils.matchesSavedMap('https://duckduckgo.com', matchDomainOnly, 'some container', {
+                  host: '<some container>duckduckgo.com',
+                })
+            ).toBe(true);
+          });
+          it('should match url with no container', () => {
+            expect(utils.matchesSavedMap('https://duckduckgo.com', matchDomainOnly, '', {
+                  host: '<>duckduckgo.com',
+                })
+            ).toBe(true);
+          });
+          it('should match url with any container when unspecified', () => {
+            expect(utils.matchesSavedMap('https://duckduckgo.com', matchDomainOnly, 'some container', {
+                  host: 'duckduckgo.com',
+                })
+            ).toBe(true);
+          });
+          it('should not match url with mismatched container', () => {
+            expect(utils.matchesSavedMap('https://duckduckgo.com', matchDomainOnly, 'some container', {
+                  host: '<other container>duckduckgo.com',
+                })
+            ).toBe(false);
           });
         });
 
@@ -85,12 +109,15 @@ describe('utils', () => {
           isRegex = !!isRegex;
           const simplePattern = isRegex?
               '@duckduckgo\\.com' : '!duckduckgo.com';
+          const containerNamePattern = isRegex?
+              '@<some container>duckduckgo\\.com' : '!<some container>duckduckgo.com';
+          
           return () => {
             it('should match url without path', () => {
               expect(
                   utils.matchesSavedMap(
                       'https://duckduckgo.com',
-                      matchDomainOnly, {
+                      matchDomainOnly, undefined, {
                         host: simplePattern,
                       })
               ).toBe(true);
@@ -99,7 +126,7 @@ describe('utils', () => {
               expect(
                   utils.matchesSavedMap(
                       'https://duckduckgo.com/?q=search+me+baby',
-                      matchDomainOnly, {
+                      matchDomainOnly, undefined, {
                         host: simplePattern,
                       })
               ).toBe(true);
@@ -110,10 +137,28 @@ describe('utils', () => {
               expect(
                   utils.matchesSavedMap(
                       'https://google.com/?q=duckduckgo',
-                      matchDomainOnly, {
+                      matchDomainOnly, undefined, {
                         host: simplePattern,
                       })
               ).toBe(!matchDomainOnly);
+            });
+            it('should match url without path and container', () => {
+              expect(
+                  utils.matchesSavedMap(
+                      'https://duckduckgo.com',
+                      matchDomainOnly, 'some container', {
+                        host: containerNamePattern,
+                      })
+              ).toBe(true);
+            });
+            it('should match url with path and container', () => {
+              expect(
+                  utils.matchesSavedMap(
+                      'https://duckduckgo.com/?q=search+me+baby',
+                      matchDomainOnly, 'some container', {
+                        host: containerNamePattern,
+                      })
+              ).toBe(true);
             });
           };
         }

--- a/src/ui-preferences/preferences.json
+++ b/src/ui-preferences/preferences.json
@@ -7,6 +7,12 @@
   },
   {
     "type": "bool",
+    "name": "matchContainerName",
+    "label": "Match current container name",
+    "description": "When matching rules to a URL, prefix the url with the current container name enclosed in angle brackets, eg. \"&amp;lt;Container 1&amp;gt;https://example.com\""
+  },
+  {
+    "type": "bool",
     "name": "keepOldTabs",
     "label": "Keep old tabs",
     "description": "After a contained tab has been created, the old won't be closed"

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,12 +74,15 @@ export const urlKeyFromUrl = (url) => {
  * @param map
  * @return {*}
  */
-export const matchesSavedMap = (url, matchDomainOnly, {host}) => {
+export const matchesSavedMap = (url, matchDomainOnly, currentContainerName, {host}) => {
   let toMatch = url;
   let urlO = new window.URL(url);
   if (matchDomainOnly) {
     toMatch = urlO.host;
     urlO = new window.URL(`${urlO.protocol}//${urlO.host}`);
+  }
+  if (currentContainerName !== undefined) {
+    toMatch = `<${currentContainerName}>${toMatch}`;
   }
 
   if (host[0] === PREFIX_REGEX) {
@@ -101,8 +104,16 @@ export const matchesSavedMap = (url, matchDomainOnly, {host}) => {
     const key = urlKeyFromUrl(urlO);
     const _url = ((key.indexOf('/') === -1) ? key.concat('/') : key).toLowerCase();
     const mapHost = ((host.indexOf('/') === -1) ? host.concat('/') : host).toLowerCase();
-    return domainMatch(_url, mapHost) && pathMatch(_url, mapHost);
-
+    
+    let mapContainer = undefined;
+    let mapUrl = mapHost;
+    if (currentContainerName !== undefined) {
+      // Extract the container name from the map host
+      [, mapContainer, mapUrl] = mapHost.match(/(?:<([^>]*)>)?(.+)/);
+    }
+    
+    return (mapContainer === undefined || mapContainer === currentContainerName) &&
+      domainMatch(_url, mapUrl) && pathMatch(_url, mapUrl);
   }
 };
 


### PR DESCRIPTION
Upstream [pull request](https://github.com/kintesh/containerise/pull/186).
> Adds a new option, "Match current container name". If enabled, the current container name is added as a prefix to match against, in angle brackets. This allows rules to control whether they apply based on the current container as well as the destination url.
> 
> Addresses:
> 
> https://github.com/kintesh/containerise/issues/154,
> https://github.com/kintesh/containerise/issues/53: Change the rule to have <> prefix and it will only apply if not already in a container
> https://github.com/kintesh/containerise/issues/24: Have a rule like @<(?!personal).*>mail\.google\.com , Work and it will switch to the Work container for mail.google.com unless the current container is already Personal.
> https://github.com/kintesh/containerise/issues/142, Have a rule like @<google>(?!.+\.google\.com).* , No Container will allow only google.com urls in the google container