### PR TITLE
Make regex and glob pattern matching stricter

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -77,45 +77,69 @@ describe('utils', () => {
           });
         });
 
-        function testPrefixes(isRegex) {
-          isRegex = !!isRegex;
-          const simplePattern = isRegex?
-              '@duckduckgo\\.com' : '!duckduckgo.com';
+        function testPrefixes(pattern, expectedUrl, evilUrl) {
           return () => {
             it('should match url without path', () => {
               expect(
                   utils.matchesSavedMap(
-                      'https://duckduckgo.com',
+                      expectedUrl,
                       matchDomainOnly, {
-                        host: simplePattern,
+                        host: pattern,
                       })
               ).toBe(true);
             });
             it('should match url with path', () => {
               expect(
                   utils.matchesSavedMap(
-                      'https://duckduckgo.com/?q=search+me+baby',
+                    expectedUrl + '/?q=search+me+baby',
                       matchDomainOnly, {
-                        host: simplePattern,
+                        host: pattern,
                       })
               ).toBe(true);
             });
             let prefix = matchDomainOnly ? 'should not' : 'should';
-            let description = `${prefix} match url with pattern only in path`;
+            let description = `${pattern} ${prefix} match ${evilUrl}`;
             it(description, () => {
               expect(
                   utils.matchesSavedMap(
-                      'https://google.com/?q=duckduckgo',
+                      evilUrl,
                       matchDomainOnly, {
-                        host: simplePattern,
+                        host: pattern,
                       })
               ).toBe(!matchDomainOnly);
             });
           };
         }
 
-        describe('with regex host prefix', testPrefixes(true));
-        describe('with glob host prefix', testPrefixes());
+        describe('with regex host prefix', testPrefixes(
+            '@duckduckgo\\.com',
+            'https://duckduckgo.com',
+            'https://google.com/?q=duckduckgo'));
+
+        describe('with glob host prefix', testPrefixes(
+            '!duckduckgo.com',
+            'https://duckduckgo.com',
+            'https://google.com/?q=duckduckgo'));
+
+        describe('with regex host prefix', testPrefixes(
+            '@duckduckgo\\.com',
+            'https://duckduckgo.com',
+            'https://evil.duckduckgo.com.evil.com'));
+
+        describe('with glob host prefix', testPrefixes(
+            '!duckduckgo.com',
+            'https://duckduckgo.com',
+            'https://evil.duckduckgo.com.evil.com'));
+
+        describe('with glob subdomain prefix', testPrefixes(
+            '!*.duckduckgo.com',
+            'https://example.duckduckgo.com',
+            'https://notduckduckgo.com'));
+
+        describe('with regex subdomain prefix', testPrefixes(
+            '@(.+)\\.duckduckgo\\.com',
+            'https://example.duckduckgo.com',
+            'https://notduckduckgo.com'));
       };
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,9 +93,10 @@ export const matchesSavedMap = (url, matchDomainOnly, {host}) => {
     // turning glob into regex isn't the worst thing:
     // 1. * becomes .*
     // 2. ? becomes .?
-    return new RegExp(host.substr(1)
-        .replace(/\*/g, '.*')
-        .replace(/\?/g, '.?'))
+    // Because the string is regex escaped, you must match \* to instead of *
+    return new RegExp(escapeRegExp(host.substr(1))
+        .replace(/\\\*/g, '.*')
+        .replace(/\\\?/g, '.?'))
         .test(toMatch);
   } else {
     const key = urlKeyFromUrl(urlO);
@@ -134,4 +135,14 @@ export function formatString(string, context) {
     }
     return replacement;
   });
+}
+
+/**
+ * Escape all regex metacharacters in a string
+ *
+ * @param string {String}
+ */
+function escapeRegExp(string) {
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,7 +83,11 @@ export const matchesSavedMap = (url, matchDomainOnly, {host}) => {
   }
 
   if (host[0] === PREFIX_REGEX) {
-    const regex = host.substr(1);
+    let regex = host.substr(1);
+    if (matchDomainOnly) {
+      // This might generate double ^^ characters, but that works anyway
+      regex = "^" + regex + "$";
+    }
     try {
       return new RegExp(regex).test(toMatch);
     } catch (e) {
@@ -94,10 +98,13 @@ export const matchesSavedMap = (url, matchDomainOnly, {host}) => {
     // 1. * becomes .*
     // 2. ? becomes .?
     // Because the string is regex escaped, you must match \* to instead of *
-    return new RegExp(escapeRegExp(host.substr(1))
-        .replace(/\\\*/g, '.*')
-        .replace(/\\\?/g, '.?'))
-        .test(toMatch);
+    let regex = escapeRegExp(host.substr(1))
+      .replace(/\\\*/g, '.*')
+      .replace(/\\\?/g, '.?')
+    if (matchDomainOnly) {
+      regex = "^" + regex + "$";
+    }
+    return new RegExp(regex).test(toMatch);
   } else {
     const key = urlKeyFromUrl(urlO);
     const _url = ((key.indexOf('/') === -1) ? key.concat('/') : key).toLowerCase();


### PR DESCRIPTION
Upstream [pull request](https://github.com/kintesh/containerise/pull/130).

> I was trying to use glob patterns and ran into one bug and one quirk that made them impossible to use correctly:
> 
> Regex metacharacters (such as .) were not escaped in globs (which use regexes for parsing internally):
> 
>     !*.example.com matched evilexample.com
>     !e.a.p.e.com matched example.com
> 
> Patterns do not match the entire domain, even with "match domain only" enabled:
> 
>     @example.com matched evil.example.com.evil.com (user fixable with regex patterns: @^example.com$ behaves as expected, but I don't want this to be necessary)
>     !example.com matched evil.example.com.evil.com (no anchors in glob patterns, not fixable by the user)
> 
> I believe it is more intuitive for patterns to always match the entire string when "match domain only" is enabled.
> 
> The first commit fixes the regex metacharacter bug and the second adds anchors when matching patterns with "match domain only" is enabled. The final commit updates the tests (not 100% if the logic is correct with the matchDomainOnly/should/should not testing).
> 
> The "match domain only" change is a breaking change. You can drop that commit if you want, but please document the current behavior. The glob example in the README matches many more domains more than just the specified domain.
> 
> A weaker change might be to add anchors only when matching glob patterns, not regexes. But note that this is a breaking change too: users might've been using example.com to match subdomains or www.example.com.
> 
> If you want the patterns to behave like prefixes it's not sufficient to only add a right $ anchor, because example\.com$ still matches evilexample.com
> 
> I'm not sure what the best solution here is.