### PR TITLE
Add support for Temporary Containers Plus extension

### DIFF
--- a/src/messageExternalListener.js
+++ b/src/messageExternalListener.js
@@ -2,6 +2,7 @@ import HostStorage from './Storage/HostStorage';
 
 const allowedExternalExtensions = [
   '{c607c8df-14a7-4f28-894f-29e8722976af}', // Temporary Containers
+  '{1ea2fa75-677e-4702-b06a-50fc7d06fe7e}', // Temporary Containers Plus
 ];
 
 export const messageExternalListener = (message, sender) => {


### PR DESCRIPTION
Submitting this PR here since this version of the Containerise addon seems to be actively managed.

The Temporary Containers addon is currently whitelisted to communicate with the Containerise addon to prevent temporary containers from being infinitely recreated when domains are assigned to reopen in a permanent container. The Temporary Containers addon is no longer under development due to the developer having passed away so it is now maintained as Temporary Containers Plus.

This PR is to add access to Temporary Containers Plus to be able to continue to communicate with Containerise as requested by users of that addon [here](https://github.com/GodKratos/temporary-containers/issues/38)