### PR TITLE
fix: label toolbar container color as black

### DIFF
--- a/src/ui-preferences/__tests__/preferences.spec.js
+++ b/src/ui-preferences/__tests__/preferences.spec.js
@@ -1,0 +1,20 @@
+import preferencesJson from '../preferences.json';
+
+describe('preferences', () => {
+
+  it('labels the Firefox toolbar color as black without changing the API value', () => {
+    const defaultContainer = preferencesJson.find(
+        preference => preference.name === 'defaultContainer'
+    );
+    const containerColor = defaultContainer.preferences.find(
+        preference => preference.name === 'containerColor'
+    );
+    const toolbarChoice = containerColor.choices.find(choice => choice.name === 'toolbar');
+
+    expect(toolbarChoice).toEqual({
+      name: 'toolbar',
+      label: 'Black',
+    });
+  });
+
+});

--- a/src/ui-preferences/preferences.json
+++ b/src/ui-preferences/preferences.json
@@ -35,7 +35,7 @@
         "choices": [
           {
             "name": "toolbar",
-            "label": "Toolbar"
+            "label": "Black"
           },
           {
             "name": "blue",


### PR DESCRIPTION
## Summary
- rename the UI label for Firefox's `toolbar` container color to `Black`
- keep the underlying value as `toolbar`, which is what Firefox expects
- add a small regression test for the preferences JSON mapping

Fixes #15.

## Verification
- `PATH=/Users/yuriibakurov/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --runInBand`
- `PATH=/Users/yuriibakurov/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npx eslint ./src`
- `git diff --check`

`npm run lint` currently reaches `web-ext lint -s ./src` and fails because `src/manifest.json` references `icons/icon.png`, while the icon is copied in from `static/` during the build flow. The ESLint portion passed.