### PR TITLE
Label toolbar container color as black

### DIFF
--- a/src/ui-preferences/__tests__/preferences.spec.js
+++ b/src/ui-preferences/__tests__/preferences.spec.js
@@ -1,0 +1,14 @@
+const preferences = require('../preferences.json');
+
+describe('preferences config', () => {
+  it('labels Firefox toolbar color as black while preserving the API value', () => {
+    const defaultContainer = preferences.find(({name}) => name === 'defaultContainer');
+    const colorPreference = defaultContainer.preferences.find(({name}) => name === 'containerColor');
+    const toolbarChoice = colorPreference.choices.find(({name}) => name === 'toolbar');
+
+    expect(toolbarChoice).toEqual({
+      name: 'toolbar',
+      label: 'Black',
+    });
+  });
+});

--- a/src/ui-preferences/preferences.json
+++ b/src/ui-preferences/preferences.json
@@ -35,7 +35,7 @@
         "choices": [
           {
             "name": "toolbar",
-            "label": "Toolbar"
+            "label": "Black"
           },
           {
             "name": "blue",


### PR DESCRIPTION
## Summary
- rename the UI label for Firefox's `toolbar` container color to `Black`
- keep the stored/API value as `toolbar` so container creation behavior is unchanged
- add a regression test for the preference config

Closes #15

## Verification
- `npm test -- --runTestsByPath src/ui-preferences/__tests__/preferences.spec.js`
- `npm test -- --runInBand`
- `npx eslint ./src`

Note: `npm run lint` reaches the repo's `web-ext lint -s ./src` step, which reports the existing missing `src/icons/icon.png` packaging layout in a fresh source checkout.