### PR TITLE
Add configurable defaults for missing CSV container appearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ google.com , Google , blue , fingerprint
 
 If the container defined in the rule already exists, the values of the color and icon will be ignored (the values of the already existing container will be fetched and used when the changes are saved).
 
-If the container defined in the rule does not exist, it will be created. If the optional values (color and icon) are not set, random values will be chosen.
+If the container defined in the rule does not exist, it will be created. If the optional values (color and icon) are not set, the CSV editor container defaults from the extension settings will be used. Both defaults are set to random unless you choose specific values.
 
 **IMPORTANT: the rule order matters! You might have more than one pattern that match your URL. In this case the first one is going to be used (the one that is closest to the top of the list).**
 

--- a/src/ui-preferences/__tests__/preferences.spec.js
+++ b/src/ui-preferences/__tests__/preferences.spec.js
@@ -1,0 +1,14 @@
+const preferences = require('../preferences.json');
+
+describe('preferences config', () => {
+  it('defines random defaults for containers created from incomplete CSV rules', () => {
+    const csvEditor = preferences.find(({name}) => name === 'csvEditor');
+    const color = csvEditor.preferences.find(({name}) => name === 'missingContainerColor');
+    const icon = csvEditor.preferences.find(({name}) => name === 'missingContainerIcon');
+
+    expect(color.defaultValue).toBe('RANDOM');
+    expect(icon.defaultValue).toBe('RANDOM');
+    expect(color.choices).toContainEqual({name: 'red', label: 'Red'});
+    expect(icon.choices).toContainEqual({name: 'briefcase', label: 'Briefcase'});
+  });
+});

--- a/src/ui-preferences/preferences.json
+++ b/src/ui-preferences/preferences.json
@@ -13,6 +13,56 @@
   },
   {
     "type": "group",
+    "name": "csvEditor",
+    "label": "CSV editor container defaults",
+    "description": "Default appearance for containers created from CSV rules that omit color or icon",
+    "preferences": [
+      {
+        "type": "dropdown",
+        "name": "missingContainerColor",
+        "label": "Container color",
+        "description": "Color used when a CSV rule does not specify one",
+        "defaultValue": "RANDOM",
+        "choices": [
+          {"name": "RANDOM", "label": "Random"},
+          {"name": "toolbar", "label": "Black"},
+          {"name": "blue", "label": "Blue"},
+          {"name": "green", "label": "Green"},
+          {"name": "orange", "label": "Orange"},
+          {"name": "pink", "label": "Pink"},
+          {"name": "purple", "label": "Purple"},
+          {"name": "red", "label": "Red"},
+          {"name": "turquoise", "label": "Turquoise"},
+          {"name": "yellow", "label": "Yellow"}
+        ]
+      },
+      {
+        "type": "dropdown",
+        "name": "missingContainerIcon",
+        "label": "Container icon",
+        "description": "Icon used when a CSV rule does not specify one",
+        "defaultValue": "RANDOM",
+        "choices": [
+          {"name": "RANDOM", "label": "Random"},
+          {"name": "circle", "label": "Circle"},
+          {"name": "fingerprint", "label": "Fingerprint"},
+          {"name": "briefcase", "label": "Briefcase"},
+          {"name": "dollar", "label": "Dollar"},
+          {"name": "cart", "label": "Cart"},
+          {"name": "gift", "label": "Gift"},
+          {"name": "vacation", "label": "Vacation"},
+          {"name": "food", "label": "Food"},
+          {"name": "fruit", "label": "Fruit"},
+          {"name": "pet", "label": "Pet"},
+          {"name": "tree", "label": "Tree"},
+          {"name": "chill", "label": "Chill"},
+          {"name": "fence", "label": "Fence"}
+        ]
+      }
+    ]
+  },
+  {
+    "type": "group",
     "name": "defaultContainer",
     "label": "Default container",
     "description": "Which container unmatched URLs will end up in",

--- a/src/ui/CSVEditor.js
+++ b/src/ui/CSVEditor.js
@@ -1,8 +1,10 @@
-import ContextualIdentities, {RANDOM_VAL_CONST as RANDOM_CONTAINER_VAL} from '../ContextualIdentity';
+import ContextualIdentities from '../ContextualIdentity';
 import State from '../State';
 import Storage from '../Storage/HostStorage';
+import PreferenceStorage from '../Storage/PreferenceStorage';
 import {cleanHostInput, MAX_EXTENSION_POPUP_WIDTH, qs, sortMaps} from '../utils';
 import {hideLoader, showLoader} from './loader';
+import {resolveMissingContainerAppearance} from './missingContainerAppearance';
 import {hideToast, showToast} from './toast';
 
 const HOST_MAPS_SPLIT_KEY = ',';
@@ -116,6 +118,7 @@ class CSVEditor {
       .filter(s => s && s.charAt(0) !== '#');
     const maps = {};
     const missingContainers = {};
+    const preferences = await PreferenceStorage.getAll(true);
 
     await Promise.all(items.map((item, priority) => {
       const hostMapParts = item.split(HOST_MAPS_SPLIT_KEY);
@@ -145,12 +148,15 @@ class CSVEditor {
         if (trimmedContainer in missingContainers) {
           missingContainers[trimmedContainer].hosts.push(hostObj);
         } else {
+          const appearance = resolveMissingContainerAppearance(
+            preferences, containerColor, containerIcon
+          );
           missingContainers[trimmedContainer] = {
             hosts: [hostObj],
             container: {
               name: trimmedContainer,
-              color: containerColor.trim() || RANDOM_CONTAINER_VAL,
-              icon: containerIcon.trim() || RANDOM_CONTAINER_VAL,
+              color: appearance.color,
+              icon: appearance.icon,
             },
           };
         }

--- a/src/ui/__tests__/missingContainerAppearance.spec.js
+++ b/src/ui/__tests__/missingContainerAppearance.spec.js
@@ -1,0 +1,33 @@
+import {
+  MISSING_CONTAINER_COLOR_PREFERENCE,
+  MISSING_CONTAINER_ICON_PREFERENCE,
+  resolveMissingContainerAppearance,
+} from '../missingContainerAppearance';
+
+describe('resolveMissingContainerAppearance', () => {
+  const preferences = {
+    [MISSING_CONTAINER_COLOR_PREFERENCE]: 'red',
+    [MISSING_CONTAINER_ICON_PREFERENCE]: 'briefcase',
+  };
+
+  it('uses CSV values when both appearance fields are present', () => {
+    expect(resolveMissingContainerAppearance(preferences, ' blue ', ' circle ')).toEqual({
+      color: 'blue',
+      icon: 'circle',
+    });
+  });
+
+  it('uses configured defaults for omitted appearance fields', () => {
+    expect(resolveMissingContainerAppearance(preferences, '', ' ')).toEqual({
+      color: 'red',
+      icon: 'briefcase',
+    });
+  });
+
+  it('preserves random fallback when preferences have not been saved', () => {
+    expect(resolveMissingContainerAppearance({}, '', '')).toEqual({
+      color: 'RANDOM',
+      icon: 'RANDOM',
+    });
+  });
+});

--- a/src/ui/missingContainerAppearance.js
+++ b/src/ui/missingContainerAppearance.js
@@ -1,0 +1,15 @@
+export const MISSING_CONTAINER_COLOR_PREFERENCE = 'csvEditor.missingContainerColor';
+export const MISSING_CONTAINER_ICON_PREFERENCE = 'csvEditor.missingContainerIcon';
+
+const RANDOM_CONTAINER_VALUE = 'RANDOM';
+
+export function resolveMissingContainerAppearance(preferences, color, icon) {
+  return {
+    color: color.trim()
+      || preferences[MISSING_CONTAINER_COLOR_PREFERENCE]
+      || RANDOM_CONTAINER_VALUE,
+    icon: icon.trim()
+      || preferences[MISSING_CONTAINER_ICON_PREFERENCE]
+      || RANDOM_CONTAINER_VALUE,
+  };
+}


### PR DESCRIPTION
## Summary

Add preferences for the color and icon used when a CSV rule creates a container without explicit appearance values.

Closes #16

## Changes

- add configurable default container color and icon preferences
- keep random selection as the default behavior
- preserve explicit CSV color and icon values
- add preference and resolution regression coverage

## Verification

- `npm test -- --runInBand` — 8/8 suites and 736/736 tests passed
- `npx eslint ./src` — passed
- production webpack build — passed
- `web-ext lint -s build/` — passed with no errors
- `web-ext build -s build/` — packaged successfully

The repository's combined `npm run lint`/`npm run build` script invokes `web-ext lint -s ./src` before webpack copies `static/icons/icon.png` into the build. That source-tree validation reports the pre-existing missing `src/icons/icon.png`; validating the generated extension under `build/` passes with no errors.
